### PR TITLE
Python 2/3 notes on bobGReeting

### DIFF
--- a/intro_computing/python_bobGreeting.py
+++ b/intro_computing/python_bobGreeting.py
@@ -1,4 +1,13 @@
+from __future__import print_function
+
+try:
+  input = raw_input
+except NameError:
+  pass
+
 from datetime import date
+
 year = input("What year were you born?")
-noOfYears = date.today().year - year
+noOfYears = date.today().year - int(year)
+
 print("You have been alive for ", noOfYears * 7, " dog years!")


### PR DESCRIPTION
## Future

[Future](https://docs.python.org/2/library/__future__.html) is a magical feature of Python which allows you to import certain features into an older version of Python.

Future works by allowing you specify a certain feature in the rest of your file by importing it. In versions of Python without that feature, it will import it. In versions with that feature already, it just gets ignored. Eg. -

Python 2

``` python
from __future__ import print_function
```

Python 3

``` python
from __future__ import print_function
```

make it work in exactly the same way for `print()`
## print statement vs function

In Python 2, `print` is a statement by default. This means that it works in a similar way to `def` - you pass it arguments without brackets, and it's somewhat limited in what it does. It does only a single thing, print things.

So you can't do you normal Pythonic things like

``` python
>>> my_print = print
  File "<stdin>", line 1
    my_print = print
                   ^
SyntaxError: invalid syntax
```

In Python 3, `print` is a function.

``` python
>>> my_print = print
>>> my_print('hello')
hello
```

If you're using the `print()` syntax for Python, you should import print_function from future. Future has docs on what you can import [here](https://docs.python.org/2/library/__future__.html). 

In Python 2, if you use `print()` syntax _without_ importing print_function from future, then you're actually passing a tuple to the `print` statement.

E.g 

Python 2 -

``` python

>>> print('hello')
hello
>>> print('hello', 'dog')
('hello', 'dog')

```

whereas in Python 3 - 

``` python

>>> print('hello', 'dog')
hello dog

```

Notice in the Python 2 version, a tuple is printed when you pass multiple arguments - this is not what you want 90% of the time. In Python 3, it just joins it with a separator - in this case a space. 

Another advantage of the Python 3 version is that you can send it a seperator to use, eg -

``` python
>>> print('hello', 'dog', sep='\n')
hello
dog
```

Using the print_function allows you to do this in Python 2 - 

``` python
>>> from __future__ import print_function
>>> print('hello', 'dog')
hello dog
>>> print('hello', 'dog', sep='\n' )
hello
dog
```
## input vs raw_input

In Python 2, `raw_input` reads a string from stdin and gives it you as a string. `input` takes a string and tries to evaluate in the running program, for example -

``` python
>>> x = 5
>>> x
5
>>> input()
x
5
>>> raw_input()
x
'x'
```

This is considered harmful and was removed in Python 3. Confusingly, they renamed `raw_input` to `input`, so instead it gives you the following:

``` python
>>> x = 5
>>> x
5
>>> input()
x
'x'
>>> raw_input()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
NameError: name 'raw_input' is not defined
```

Now, to write code that works in both Python 2 and Python 3 in the same way, we can use a nice little trick - using a new name to point to an existing object (in this case, our new name is `input`, and our existing object is the `raw_input` function)

Let's try that in Python 2 - 

``` python
>>> input = raw_input
>>> input()
x
'x'
```

Great, it works perfectly! But let's try it on Python 3..

``` python

>>> raw_input()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
NameError: name 'raw_input' is not defined
>>> input = raw_input
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
NameError: name 'raw_input' is not defined

```

Damn it! It throws a NameError, so we can't do that!

Except we can.

``` python
>>> try:
...   input = raw_input
... except NameError:
...   pass
... 
>>> input()
x
'x'
```

Here we use another little trick - names which aren't defined will raise the Error `NameError` when they can't be found. So, we try to point the name `input` to the object named by `raw_input`. When that fails, we use `pass` to just do nothing about it at all. `input` is still what we want it to be!
## and now for something completely different

Then finally, 

``` python
noOfYears = date.today().year - int(year)
```

we now have to use `int()` to convert the string `year` into an `int`.
